### PR TITLE
Add image uploads page and polish UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.env
+__pycache__/
+*.pyc
+debug.log
+app.log
+static/uploads/*
+!static/uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Discord Trading Card Bot
+
+This project contains a basic Discord bot and a web-based admin UI for managing trading card inventory.
+
+## Features
+- Register as a seller and choose Discord channels used for inventory listings and claims.
+- Add categories and trading cards via a web interface.
+- Each category is announced with an embed containing an **Explore** button.
+- Users can browse cards in an ephemeral message grid (3x3 on desktop, 2x2 on mobile).
+- Cards include front/back images and can be claimed or unclaimed.
+- Batch add cards with paired front/back images.
+- Customize embed title, description, button text, color, images and footer via the Embed Builder tab with a live preview.
+- Delete categories and cards directly from the admin pages.
+- Upload and manage image files from the **Uploads** tab.
+- Admin options are organized into tabs for clarity.
+- Configure channel IDs and grid size from the new **Settings** tab.
+- Claims are summarized in a persistent message that updates whenever a card is claimed or unclaimed.
+
+## Setup
+1. Create a Discord application and bot, then obtain your token.
+2. Clone this repository and install dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+   If you see `ModuleNotFoundError: No module named 'dotenv'`, ensure the
+   `python-dotenv` package was installed by running the command above.
+3. Copy `example.env` to `.env` and fill in your Discord bot token and preferred settings. If no `ADMIN_PASSWORD` is defined, the default login password is `change-me`.
+4. Run the web app and bot in separate terminals:
+   ```bash
+   python app.py
+   ```
+   ```bash
+   python bot.py
+   ```
+
+Use the **Settings** tab in the admin UI to set the channel IDs used for
+inventory messages, claims updates and the image dump. You can also adjust the
+grid size used when browsing cards.
+
+Upload reference images directly from the **Uploads** tab and then copy the URLs
+when adding cards or building embeds.
+
+The bot reads configuration from `.env` and `data/inventory.json`.
+
+Use the tabs at the top of the admin UI to switch between inventory management and the embed builder preview.
+
+All server and bot actions are logged to a file specified by the `DEBUG_LOG`
+environment variable (defaults to `debug.log` in the project root). Check this
+file when troubleshooting.
+
+## Notes
+This is a starting point and does not include advanced authentication or hosting setup. Add your own enhancements as needed.
+
+## Resolving merge conflicts
+If you see conflict markers like `<<<<<<<` in your files, remove the markers and choose the desired lines. After editing, stage the changes with `git add` and run `git commit` to finalize the resolution.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,218 @@
+from flask import (
+    Flask,
+    request,
+    redirect,
+    render_template,
+    render_template_string,
+    session,
+    url_for,
+)
+from werkzeug.utils import secure_filename
+from data_manager import load_data, save_data
+import logging
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        print("Warning: python-dotenv not installed; .env file will be ignored")
+import os
+
+load_dotenv()
+
+logging.basicConfig(
+    filename=os.getenv('DEBUG_LOG', 'debug.log'),
+    level=logging.DEBUG,
+    format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+    filemode='a'
+)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+app.secret_key = os.getenv('ADMIN_PASSWORD', 'change-me')
+
+
+def require_login(func):
+    def wrapper(*args, **kwargs):
+        if not session.get('logged_in'):
+            logger.debug('Unauthorized access attempt to %s', request.path)
+            return redirect('/')
+        return func(*args, **kwargs)
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        logger.debug('Login attempt')
+        if request.form.get('password') == os.getenv('ADMIN_PASSWORD', 'change-me'):
+            session['logged_in'] = True
+            logger.debug('Login successful')
+            return redirect('/inventory')
+        logger.debug('Login failed')
+    return render_template('index.html')
+
+
+@app.route('/inventory')
+@require_login
+def inventory():
+    logger.debug('Rendering inventory list')
+    data = load_data()
+    return render_template('inventory.html', data=data)
+
+
+@app.route('/embed-builder', methods=['GET', 'POST'])
+@require_login
+def embed_builder():
+    logger.debug('Accessing embed builder')
+    data = load_data()
+    embed = data.get('embed', {})
+    if request.method == 'POST':
+        embed = {
+            'title': request.form.get('title', ''),
+            'description': request.form.get('description', ''),
+            'button_label': request.form.get('button_label', 'Explore'),
+            'color': request.form.get('color', '#ffffff'),
+            'thumbnail': request.form.get('thumbnail', ''),
+            'image': request.form.get('image', ''),
+            'footer': request.form.get('footer', ''),
+        }
+        data['embed'] = embed
+        save_data(data)
+    return render_template('embed_builder.html', embed=embed)
+
+
+@app.route('/settings', methods=['GET', 'POST'])
+@require_login
+def settings():
+    logger.debug('Accessing settings')
+    data = load_data()
+    settings = data.get('settings', {})
+    if request.method == 'POST':
+        settings = {
+            'inventory_channel_id': request.form.get('inventory_channel_id', ''),
+            'claims_channel_id': request.form.get('claims_channel_id', ''),
+            'image_channel_id': request.form.get('image_channel_id', ''),
+            'grid_size': int(request.form.get('grid_size', '3')),
+        }
+        data['settings'] = settings
+        save_data(data)
+    return render_template('settings.html', settings=settings)
+
+
+@app.route('/uploads', methods=['GET', 'POST'])
+@require_login
+def uploads():
+    """Upload and list image files."""
+    upload_dir = os.path.join('static', 'uploads')
+    os.makedirs(upload_dir, exist_ok=True)
+    if request.method == 'POST':
+        files = request.files.getlist('images')
+        logger.debug('Uploading %s images', len(files))
+        for f in files:
+            if not f.filename:
+                continue
+            fname = secure_filename(f.filename)
+            path = os.path.join(upload_dir, fname)
+            f.save(path)
+            logger.debug('Saved image %s', path)
+    images = os.listdir(upload_dir)
+    images.sort()
+    images = [os.path.join('/static/uploads', img) for img in images]
+    return render_template('uploads.html', images=images)
+
+
+@app.route('/add-category', methods=['GET', 'POST'])
+@require_login
+def add_category():
+    data = load_data()
+    if request.method == 'POST':
+        name = request.form.get('name')
+        logger.debug('Adding category %s', name)
+        cat_id = str(len(data['categories']) + 1)
+        data['categories'].append({'id': cat_id, 'name': name, 'cards': []})
+        save_data(data)
+        return redirect('/inventory')
+    return render_template_string('''\
+        {% extends 'layout.html' %}
+        {% block content %}
+        <h2>Add Category</h2>
+        <form method="post">
+            <label>Name: <input type="text" name="name"></label>
+            <button type="submit" class="button">Save</button>
+        </form>
+        {% endblock %}
+    ''')
+
+
+@app.route('/delete-category/<cat_id>', methods=['POST'])
+@require_login
+def delete_category(cat_id):
+    data = load_data()
+    logger.debug('Deleting category %s', cat_id)
+    data['categories'] = [c for c in data['categories'] if c['id'] != cat_id]
+    save_data(data)
+    return redirect('/inventory')
+
+
+@app.route('/category/<cat_id>', methods=['GET', 'POST'])
+@require_login
+def manage_category(cat_id):
+    logger.debug('Managing category %s', cat_id)
+    data = load_data()
+    cat = next((c for c in data['categories'] if c['id'] == cat_id), None)
+    if not cat:
+        logger.debug('Category %s not found', cat_id)
+        return 'Category not found', 404
+    if request.method == 'POST':
+        action = request.form.get('action')
+        if action == 'add-card':
+            card = {
+                'id': str(len(cat['cards']) + 1),
+                'name': request.form.get('name'),
+                'front': request.form.get('front'),
+                'back': request.form.get('back'),
+                'claimed_by': None,
+            }
+            logger.debug('Adding card %s to category %s', card['name'], cat_id)
+            cat['cards'].append(card)
+            save_data(data)
+        elif action == 'batch-add':
+            names = [n.strip() for n in request.form.get('names', '').splitlines() if n.strip()]
+            files = request.files.getlist('images')
+            logger.debug('Batch adding %s cards with %s images', len(names), len(files))
+            upload_dir = os.path.join('static', 'uploads')
+            os.makedirs(upload_dir, exist_ok=True)
+            for idx, name in enumerate(names):
+                front_file = files[2*idx] if len(files) > 2*idx else None
+                back_file = files[2*idx+1] if len(files) > 2*idx+1 else None
+                front_path = back_path = ''
+                if front_file:
+                    fname = secure_filename(front_file.filename)
+                    front_path = os.path.join(upload_dir, f'f_{len(cat["cards"])}_{fname}')
+                    front_file.save(front_path)
+                if back_file:
+                    fname = secure_filename(back_file.filename)
+                    back_path = os.path.join(upload_dir, f'b_{len(cat["cards"])}_{fname}')
+                    back_file.save(back_path)
+                card = {
+                    'id': str(len(cat['cards']) + 1),
+                    'name': name,
+                    'front': '/' + front_path if front_path else '',
+                    'back': '/' + back_path if back_path else '',
+                    'claimed_by': None,
+                }
+                logger.debug('Batch add card %s', card['name'])
+                cat['cards'].append(card)
+            save_data(data)
+        elif action == 'delete-card':
+            card_id = request.form.get('card_id')
+            logger.debug('Deleting card %s from category %s', card_id, cat_id)
+            cat['cards'] = [c for c in cat['cards'] if c['id'] != card_id]
+            save_data(data)
+    return render_template('category.html', category=cat)
+
+
+if __name__ == '__main__':
+    logger.info('Starting Flask app')
+    app.run(debug=True)

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,247 @@
+import os
+import logging
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        print("Warning: python-dotenv not installed; .env file will be ignored")
+import discord
+from discord.ext import commands
+from data_manager import load_data, save_data
+
+load_dotenv()
+logging.basicConfig(
+    filename=os.getenv('DEBUG_LOG', 'debug.log'),
+    level=logging.DEBUG,
+    format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+    filemode='a'
+)
+logger = logging.getLogger(__name__)
+TOKEN = os.getenv('DISCORD_TOKEN')
+
+intents = discord.Intents.default()
+intents.messages = True
+intents.message_content = True
+
+bot = commands.Bot(command_prefix='!', intents=intents)
+
+def build_category_embed(cat, config=None):
+    config = config or {}
+    title = config.get('title', cat['name'])
+    description = config.get('description', 'Explore cards')
+    try:
+        color = int(config.get('color', '#ffffff').lstrip('#'), 16)
+    except ValueError:
+        color = 0xFFFFFF
+    embed = discord.Embed(title=title, description=description, color=color)
+    if config.get('thumbnail'):
+        embed.set_thumbnail(url=config['thumbnail'])
+    if config.get('image'):
+        embed.set_image(url=config['image'])
+    if config.get('footer'):
+        embed.set_footer(text=config['footer'])
+    return embed
+
+
+async def update_claims_message(guild):
+    """Update or create the persistent claims summary message."""
+    data = load_data()
+    settings = data.get('settings', {})
+    channel_id = settings.get('claims_channel_id')
+    if not channel_id:
+        return
+    channel = guild.get_channel(int(channel_id))
+    if not channel:
+        return
+    # Build summary
+    lines = []
+    for cat in data.get('categories', []):
+        for card in cat.get('cards', []):
+            if card.get('claimed_by'):
+                lines.append(f"{card['name']} - {card['claimed_by']}")
+    summary = "\n".join(lines) or "No claims yet"
+    message_id = settings.get('claims_message_id')
+    msg = None
+    if message_id:
+        try:
+            msg = await channel.fetch_message(int(message_id))
+            await msg.edit(content=summary)
+        except discord.NotFound:
+            msg = None
+    if msg is None:
+        msg = await channel.send(summary)
+        settings['claims_message_id'] = str(msg.id)
+        save_data(data)
+
+class ExploreView(discord.ui.View):
+    def __init__(self, user, cat, grid_size):
+        super().__init__(timeout=300)
+        self.user = user
+        self.cat = cat
+        self.index = 0
+        self.grid_size = grid_size
+        self.per_page = grid_size * grid_size
+        logger.debug('Opening ExploreView for %s in category %s', user, cat['id'])
+        self.update_children()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user.id == self.user.id
+
+    def update_children(self):
+        self.clear_items()
+        logger.debug('Updating ExploreView buttons index=%s', self.index)
+        cards = self.cat['cards'][self.index:self.index + self.per_page]
+        rows = self.grid_size
+        for i, card in enumerate(cards):
+            button = discord.ui.Button(label=card['name'], style=discord.ButtonStyle.grey, row=i // rows)
+            button.callback = self.make_view_card(card)
+            self.add_item(button)
+        if self.index > 0:
+            prev_btn = discord.ui.Button(label='Prev', style=discord.ButtonStyle.blurple)
+            prev_btn.callback = self.prev_page
+            self.add_item(prev_btn)
+        if self.index + self.per_page < len(self.cat['cards']):
+            next_btn = discord.ui.Button(label='Next', style=discord.ButtonStyle.blurple)
+            next_btn.callback = self.next_page
+            self.add_item(next_btn)
+
+    def make_view_card(self, card):
+        async def callback(interaction: discord.Interaction):
+            logger.debug('Viewing card %s from category %s', card['id'], self.cat['id'])
+            embed = discord.Embed(title=card['name'])
+            embed.set_image(url=card['front'])
+            view = CardView(self.user, self.cat, card)
+            await interaction.response.edit_message(embed=embed, view=view)
+        return callback
+
+    async def prev_page(self, interaction: discord.Interaction):
+        self.index = max(0, self.index - self.per_page)
+        logger.debug('ExploreView prev_page index=%s', self.index)
+        self.update_children()
+        await interaction.response.edit_message(view=self)
+
+    async def next_page(self, interaction: discord.Interaction):
+        self.index += self.per_page
+        logger.debug('ExploreView next_page index=%s', self.index)
+        self.update_children()
+        await interaction.response.edit_message(view=self)
+
+class CardView(discord.ui.View):
+    def __init__(self, user, cat, card):
+        super().__init__(timeout=300)
+        self.user = user
+        self.cat = cat
+        self.card = card
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user.id == self.user.id
+
+    @discord.ui.button(label='Left', style=discord.ButtonStyle.secondary)
+    async def left(self, interaction: discord.Interaction, button: discord.ui.Button):
+        logger.debug('Showing back of card %s', self.card['id'])
+        embed = discord.Embed(title=self.card['name'])
+        embed.set_image(url=self.card['back'])
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label='Right', style=discord.ButtonStyle.secondary)
+    async def right(self, interaction: discord.Interaction, button: discord.ui.Button):
+        logger.debug('Showing front of card %s', self.card['id'])
+        embed = discord.Embed(title=self.card['name'])
+        embed.set_image(url=self.card['front'])
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label='Claim', style=discord.ButtonStyle.green)
+    async def claim(self, interaction: discord.Interaction, button: discord.ui.Button):
+        data = load_data()
+        cat = next((c for c in data['categories'] if c['id'] == self.cat['id']), None)
+        card = next((x for x in cat['cards'] if x['id'] == self.card['id']), None)
+        if card and not card.get('claimed_by'):
+            logger.debug('Card %s claimed by %s', self.card['id'], interaction.user)
+            card['claimed_by'] = interaction.user.name
+            save_data(data)
+            await interaction.response.send_message('Claimed!', ephemeral=True)
+            await update_claims_message(interaction.guild)
+        else:
+            await interaction.response.send_message('Already claimed', ephemeral=True)
+
+    @discord.ui.button(label='Unclaim', style=discord.ButtonStyle.red)
+    async def unclaim(self, interaction: discord.Interaction, button: discord.ui.Button):
+        data = load_data()
+        cat = next((c for c in data['categories'] if c['id'] == self.cat['id']), None)
+        card = next((x for x in cat['cards'] if x['id'] == self.card['id']), None)
+        if card and card.get('claimed_by') == interaction.user.name:
+            logger.debug('Card %s unclaimed by %s', self.card['id'], interaction.user)
+            card['claimed_by'] = None
+            save_data(data)
+            await interaction.response.send_message('Unclaimed', ephemeral=True)
+            await update_claims_message(interaction.guild)
+        else:
+            await interaction.response.send_message('Cannot unclaim', ephemeral=True)
+
+    @discord.ui.button(label='Back', style=discord.ButtonStyle.secondary)
+    async def back(self, interaction: discord.Interaction, button: discord.ui.Button):
+        logger.debug('Returning to card list for category %s', self.cat['id'])
+        data = load_data()
+        grid = data.get('settings', {}).get('grid_size', 3)
+        view = ExploreView(self.user, self.cat, grid)
+        data = load_data()
+        embed = build_category_embed(self.cat, data.get('embed'))
+        await interaction.response.edit_message(embed=embed, view=view)
+
+@bot.command()
+async def register(ctx):
+    logger.debug('Register command invoked by %s', ctx.author)
+    data = load_data()
+    settings = data.get('settings', {})
+    embed_cfg = data.get('embed', {})
+    channel = ctx.channel
+    if settings.get('inventory_channel_id'):
+        chan = ctx.guild.get_channel(int(settings['inventory_channel_id']))
+        if chan:
+            channel = chan
+    claims_chan = None
+    if settings.get('claims_channel_id'):
+        claims_chan = ctx.guild.get_channel(int(settings['claims_channel_id']))
+    for cat in data['categories']:
+        embed = build_category_embed(cat, embed_cfg)
+        view = discord.ui.View()
+        label = embed_cfg.get('button_label', 'Explore')
+        view.add_item(discord.ui.Button(label=label, custom_id=f'explore_{cat["id"]}'))
+        msg = await channel.send(embed=embed, view=view)
+        cat['message_id'] = msg.id
+    save_data(data)
+    await ctx.send('Registration complete.')
+    if claims_chan:
+        await update_claims_message(ctx.guild)
+
+@bot.event
+async def on_ready():
+    logger.info('Logged in as %s', bot.user)
+
+@bot.event
+async def on_interaction(interaction: discord.Interaction):
+    if interaction.type == discord.InteractionType.component:
+        custom = interaction.data.get('custom_id', '')
+        if custom.startswith('explore_'):
+            cat_id = custom.split('_', 1)[1]
+            logger.debug('Explore interaction for category %s by %s', cat_id, interaction.user)
+            data = load_data()
+            cat = next((c for c in data['categories'] if c['id'] == cat_id), None)
+            if not cat:
+                logger.debug('Category %s missing for interaction', cat_id)
+                await interaction.response.send_message('Category missing', ephemeral=True)
+                return
+            settings = data.get('settings', {})
+            grid = settings.get('grid_size', 3)
+            try:
+                if interaction.user.is_on_mobile():
+                    grid = min(grid, 2)
+            except AttributeError:
+                pass
+            view = ExploreView(interaction.user, cat, grid)
+            embed = build_category_embed(cat, data.get('embed'))
+            await interaction.response.send_message(embed=embed, ephemeral=True, view=view)
+
+if __name__ == '__main__':
+    logger.info('Starting Discord bot')
+    bot.run(TOKEN)

--- a/data/inventory.json
+++ b/data/inventory.json
@@ -1,0 +1,19 @@
+{
+  "categories": [],
+  "embed": {
+    "title": "",
+    "description": "",
+    "button_label": "Explore",
+    "color": "#ffffff",
+    "thumbnail": "",
+    "image": "",
+    "footer": ""
+  },
+  "settings": {
+    "inventory_channel_id": "",
+    "claims_channel_id": "",
+    "image_channel_id": "",
+    "grid_size": 3,
+    "claims_message_id": ""
+  }
+}

--- a/data_manager.py
+++ b/data_manager.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+import logging
+
+DATA_FILE = Path('data/inventory.json')
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_DATA = {
+    "categories": [],
+    "embed": {
+        "title": "",
+        "description": "",
+        "button_label": "Explore",
+        "color": "#ffffff",
+        "thumbnail": "",
+        "image": "",
+        "footer": "",
+    },
+    "settings": {
+        "inventory_channel_id": "",
+        "claims_channel_id": "",
+        "image_channel_id": "",
+        "grid_size": 3,
+        "claims_message_id": "",
+    },
+}
+
+
+def load_data():
+    """Load inventory and embed configuration."""
+    logger.debug('Loading data from %s', DATA_FILE)
+    if DATA_FILE.exists():
+        try:
+            with open(DATA_FILE) as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            logger.error('Corrupted JSON in %s, backing up and resetting', DATA_FILE)
+            backup = DATA_FILE.with_suffix(DATA_FILE.suffix + '.bak')
+            DATA_FILE.rename(backup)
+            logger.info('Moved bad file to %s', backup)
+            data = DEFAULT_DATA.copy()
+        for k, v in DEFAULT_DATA.items():
+            if isinstance(v, dict):
+                data.setdefault(k, {})
+                for sk, sv in v.items():
+                    data[k].setdefault(sk, sv)
+            else:
+                data.setdefault(k, v)
+        return data
+    return DEFAULT_DATA.copy()
+
+
+def save_data(data):
+    logger.debug('Saving data to %s', DATA_FILE)
+    DATA_FILE.parent.mkdir(exist_ok=True)
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)

--- a/example.env
+++ b/example.env
@@ -1,0 +1,3 @@
+DISCORD_TOKEN=your-token-here
+ADMIN_PASSWORD=change-me
+DEBUG_LOG=debug.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py==2.3.2
+Flask==2.2.5
+python-dotenv==1.0.0

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,37 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const title = document.querySelector('input[name="title"]');
+  const desc = document.querySelector('textarea[name="description"]');
+  const btnLabel = document.querySelector('input[name="button_label"]');
+  const color = document.querySelector('input[name="color"]');
+  const thumbnail = document.querySelector('input[name="thumbnail"]');
+  const image = document.querySelector('input[name="image"]');
+  const footer = document.querySelector('input[name="footer"]');
+  const pTitle = document.getElementById('p-title');
+  const pDesc = document.getElementById('p-desc');
+  const pButton = document.getElementById('p-button');
+  const pThumb = document.getElementById('p-thumb');
+  const pImage = document.getElementById('p-image');
+  const pFooter = document.getElementById('p-footer');
+  function update() {
+    pTitle.textContent = title.value;
+    pDesc.textContent = desc.value;
+    pButton.textContent = btnLabel.value;
+    pButton.style.background = color.value;
+    document.getElementById('preview').style.borderColor = color.value;
+    if (thumbnail.value) {
+      pThumb.src = thumbnail.value;
+      pThumb.style.display = 'block';
+    } else {
+      pThumb.style.display = 'none';
+    }
+    if (image.value) {
+      pImage.src = image.value;
+      pImage.style.display = 'block';
+    } else {
+      pImage.style.display = 'none';
+    }
+    pFooter.textContent = footer.value;
+  }
+  [title, desc, btnLabel, color, thumbnail, image, footer].forEach(el => el && el.addEventListener('input', update));
+  update();
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,104 @@
+body {
+  background: #1a1a1a;
+  color: #f0f0f0;
+  font-family: 'Inter', sans-serif;
+}
+header, nav, main {
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 0 10px;
+}
+.tabs {
+  display: flex;
+}
+.tabs a {
+  padding: 8px 12px;
+  margin-right: 4px;
+  background: #2c2c2c;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 4px 4px 0 0;
+}
+.tabs a.active {
+  background: #3d3d3d;
+}
+.embed-preview {
+  background: #2c2c2c;
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 4px;
+  border: 2px solid #2c2c2c;
+  display: inline-block;
+  min-width: 200px;
+}
+h1, h2, h3 {
+  font-family: 'Orbitron', sans-serif;
+  color: #ffeb3b;
+}
+a {
+  color: #ef4444;
+}
+.button {
+  background: #b91c1c;
+  color: #ffffff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+.button:hover {
+  background: #7f1d1d;
+}
+.inline-form {
+  display: inline;
+  margin-left: 4px;
+}
+.card {
+  background: #2c2c2c;
+  padding: 10px;
+  margin: 5px;
+  border-radius: 4px;
+}
+.card form, form.card {
+  margin-bottom: 10px;
+}
+
+.card img {
+  max-width: 50px;
+  margin-right: 8px;
+}
+
+label {
+  display: block;
+  margin: 6px 0;
+}
+
+input[type="text"], input[type="number"], textarea {
+  background: #3d3d3d;
+  border: 1px solid #2c2c2c;
+  color: #ffffff;
+  padding: 4px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.thumb-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+.thumb-list li {
+  margin: 4px;
+  text-align: center;
+  background: #2c2c2c;
+  padding: 6px;
+  border-radius: 4px;
+  width: 120px;
+  word-break: break-all;
+}
+.thumb-list img.thumb {
+  max-width: 100px;
+  max-height: 100px;
+  display: block;
+  margin: 0 auto 4px;
+}

--- a/templates/category.html
+++ b/templates/category.html
@@ -1,0 +1,36 @@
+{% extends 'layout.html' %}
+{% block content %}
+  <h2>{{ category.name }}</h2>
+  <form method="post">
+    <input type="hidden" name="action" value="add-card">
+    <label>Name: <input type="text" name="name"></label>
+    <label>Front URL: <input type="text" name="front"></label>
+    <label>Back URL: <input type="text" name="back"></label>
+    <button type="submit" class="button">Add Card</button>
+  </form>
+  <h3>Batch Add</h3>
+  <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="action" value="batch-add">
+    <label>Card Names (one per line):<br>
+      <textarea name="names" rows="4" cols="40"></textarea>
+    </label><br>
+    <label>Images (front/back pairs):<input type="file" name="images" multiple></label><br>
+    <button type="submit" class="button">Upload</button>
+  </form>
+  <p><a href="{{ url_for('uploads') }}" class="button">Manage Images</a></p>
+  <ul>
+  {% for card in category.cards %}
+    <li class="card">
+      <img src="{{ card.front }}" alt="" style="max-width:50px; vertical-align:middle;">
+      {{ card.name }} - {{ 'claimed by ' + card.claimed_by if card.claimed_by else 'unclaimed' }}
+      <form method="post" class="inline-form">
+        <input type="hidden" name="action" value="delete-card">
+        <input type="hidden" name="card_id" value="{{ card.id }}">
+        <button type="submit" class="button">Delete</button>
+      </form>
+    </li>
+  {% else %}
+    <li>No cards</li>
+  {% endfor %}
+  </ul>
+{% endblock %}

--- a/templates/embed_builder.html
+++ b/templates/embed_builder.html
@@ -1,0 +1,23 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Embed Builder</h2>
+<form method="post">
+  <label>Title: <input type="text" name="title" value="{{ embed.title }}"></label><br>
+  <label>Description:<br><textarea name="description" rows="4" cols="40">{{ embed.description }}</textarea></label><br>
+  <label>Button Label: <input type="text" name="button_label" value="{{ embed.button_label or 'Explore' }}"></label><br>
+  <label>Color: <input type="color" name="color" value="{{ embed.color or '#ffffff' }}"></label><br>
+  <label>Thumbnail URL: <input type="text" name="thumbnail" value="{{ embed.thumbnail }}"></label><br>
+  <label>Image URL: <input type="text" name="image" value="{{ embed.image }}"></label><br>
+  <label>Footer Text: <input type="text" name="footer" value="{{ embed.footer }}"></label><br>
+  <button type="submit" class="button">Save</button>
+</form>
+<div id="preview" class="embed-preview" style="border-color: {{ embed.color or '#2c2c2c' }}">
+  <h3 id="p-title"></h3>
+  <p id="p-desc"></p>
+  <img id="p-thumb" style="display:none; max-width:50px;"/>
+  <img id="p-image" style="display:none; max-width:200px;"/>
+  <button id="p-button" class="button"></button>
+  <p id="p-footer" style="font-size:0.8em;"></p>
+</div>
+<script src="/static/main.js"></script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+{% extends 'layout.html' %}
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    <label>Password: <input type="password" name="password"></label>
+    <button type="submit" class="button">Login</button>
+  </form>
+{% endblock %}

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -1,0 +1,18 @@
+{% extends 'layout.html' %}
+{% block content %}
+  <h2>Inventory</h2>
+  <a href="/add-category" class="button">Add Category</a>
+  <ul>
+  {% for cat in data.categories %}
+    <li class="card">
+      <strong>{{ cat.name }}</strong> ({{ cat.id }}) - {{ cat.cards|length }} cards
+      <a href="/category/{{ cat.id }}" class="button">Manage</a>
+      <form method="post" action="/delete-category/{{ cat.id }}" class="inline-form">
+        <button type="submit" class="button">Delete</button>
+      </form>
+    </li>
+  {% else %}
+    <li>No categories</li>
+  {% endfor %}
+  </ul>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title or 'Admin' }}</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Orbitron:wght@500;700&display=swap">
+    <link rel="stylesheet" href="/static/styles.css">
+  </head>
+  <body>
+    <header>
+      <h1>Trading Card Admin</h1>
+    </header>
+    <nav class="tabs">
+      <a href="{{ url_for('inventory') }}" class="{% if request.path == '/inventory' %}active{% endif %}">Inventory</a>
+      <a href="{{ url_for('embed_builder') }}" class="{% if request.path == '/embed-builder' %}active{% endif %}">Embed Builder</a>
+      <a href="{{ url_for('settings') }}" class="{% if request.path == '/settings' %}active{% endif %}">Settings</a>
+      <a href="{{ url_for('uploads') }}" class="{% if request.path == '/uploads' %}active{% endif %}">Uploads</a>
+    </nav>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Settings</h2>
+<form method="post">
+  <label>Inventory Channel ID:
+    <input type="text" name="inventory_channel_id" value="{{ settings.inventory_channel_id }}">
+  </label><br>
+  <label>Claims Channel ID:
+    <input type="text" name="claims_channel_id" value="{{ settings.claims_channel_id }}">
+  </label><br>
+  <label>Image Dump Channel ID:
+    <input type="text" name="image_channel_id" value="{{ settings.image_channel_id }}">
+  </label><br>
+  <label>Grid Size:
+    <input type="number" name="grid_size" min="2" max="3" value="{{ settings.grid_size or 3 }}">
+  </label><br>
+  <button type="submit" class="button">Save</button>
+</form>
+{% endblock %}

--- a/templates/uploads.html
+++ b/templates/uploads.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Uploads</h2>
+<form method="post" enctype="multipart/form-data" class="card">
+  <label>Select Images:<input type="file" name="images" multiple></label>
+  <button type="submit" class="button">Upload</button>
+</form>
+<ul class="thumb-list">
+{% for img in images %}
+  <li><img src="{{ img }}" alt="" class="thumb"><br>{{ img }}</li>
+{% else %}
+  <li>No images uploaded yet.</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new `/uploads` route for managing images
- include "Uploads" in navigation and category page link
- display uploaded image thumbnails with new styles
- tweak layout spacing for forms
- document uploads tab in README

## Testing
- `python -m py_compile app.py bot.py data_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_686dedebf9ac83289c3c9e10ae3b2dbc